### PR TITLE
Handle nil referenced objects as a normal error, instead of as a fatal error.

### DIFF
--- a/Sources/GarageStorage/Garage+MappableObject.swift
+++ b/Sources/GarageStorage/Garage+MappableObject.swift
@@ -196,7 +196,9 @@ extension Garage {
         let type = dictionary[CoreDataObject.Attribute.type] as! String
         let identifier = dictionary[CoreDataObject.Attribute.identifier] as! String
         
-        let referencedObject = fetchObject(for: type, identifier: identifier)!
+        guard let referencedObject = fetchObject(for: type, identifier: identifier) else {
+            throw Garage.makeError("Failed to fetch referenced object for type: \(type) identifier: \(identifier)")
+        }
         return try makeMappableObject(from: referencedObject)
     }
     

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -82,6 +82,30 @@ class MappableObjectTests: XCTestCase {
         }
     }
     
+    func testMissingReferencedObject() {
+        let garage = Garage()
+
+        // Create a "Sam" person and park it.
+        do {
+            let sam = objCPerson()
+            XCTAssertNoThrow(try garage.parkObject(sam), "parkObject")
+        }
+        
+        // Retrieve Nick and remove him
+        do {
+            let nick = try? garage.retrieveObject(ObjCPerson.self, identifier: "Nick")
+            XCTAssertNotNil(nick, "Failed to retrieve 'Nick' from garage store")
+            
+            XCTAssertNoThrow(try garage.deleteObject(nick!))
+        }
+        
+        // Now try to retrieve Sam. This should fail because Sam references Nick, and Nick has been removed from storage.
+        do {
+            let sam = try? garage.retrieveObject(ObjCPerson.self, identifier: "Sam")
+            XCTAssertNil(sam, "Should not have been able to retrieve 'Sam' from garage store")
+        }
+    }
+    
     func testNilObject() {
         // This tests the Objective-C interface to parkObject, which throws in Swift.
         let garage = Garage()


### PR DESCRIPTION
Replaced a fatal error if unable to retrieve a referenced object, to throw an error instead.