### PR TITLE
Fixes time zone tests including IsoFormatttedDate

### DIFF
--- a/Tests/GarageStorageTests/BootstrapTests.swift
+++ b/Tests/GarageStorageTests/BootstrapTests.swift
@@ -16,6 +16,7 @@ class BootstrapTests: XCTestCase {
  
     // Ensure that the Documents directory exists (first time in Simulator)
     override class func setUp() {
+        TestSetup.classSetUp()
         let fileManager = FileManager.default
         let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).last!
         if !fileManager.fileExists(atPath: documentsDirectory.path) {

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -15,6 +15,10 @@ import CoreData
 // This set of tests use Swift-declared Objective-C-compatible MappableObjects.
 class MappableObjectTests: XCTestCase {
     
+    override class func setUp() {
+        TestSetup.classSetUp()
+    }
+    
     override func setUp() {
         // Reset the underlying storage before running each test.
         let garage = Garage()

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -13,6 +13,10 @@ import CoreData
 // This set of tests checks Codable (hence "Swift-y") types.
 class SwiftCodableTests: XCTestCase {
 
+    override class func setUp() {
+        TestSetup.classSetUp()
+    }
+    
     override func setUp() {
         // Reset the underlying storage before running each test.
         let garage = Garage()
@@ -291,7 +295,7 @@ class SwiftCodableTests: XCTestCase {
             
             // Set sam's birthdate to 1950/01/01 04:00:00
 
-            let timeZone = TimeZone(identifier: "America/New_York")!
+            let timeZone = TestSetup.timeZone
             var dateComponents = DateComponents()
             dateComponents.day = 1
             dateComponents.month = 1
@@ -301,7 +305,7 @@ class SwiftCodableTests: XCTestCase {
             var calendar = Calendar.current
             calendar.timeZone = timeZone
             sam.birthdate = calendar.date(from: dateComponents)!
-            XCTAssertEqual(sam.birthdate.timeIntervalSinceReferenceDate, -1609441200.0, "Making assumption about the test")
+            XCTAssertEqual(sam.birthdate.timeIntervalSinceReferenceDate, -1609459200.0, "Making assumption about the test")
             
             XCTAssertNoThrow(try garage.park(sam), "parkObject")
         }
@@ -310,7 +314,7 @@ class SwiftCodableTests: XCTestCase {
             let sam = try? garage.retrieve(SwiftPerson.self, identifier: "Sam")
             XCTAssertNotNil(sam, "Failed to retrieve 'Sam' from garage store")
 
-            XCTAssertEqual(sam?.birthdate.timeIntervalSinceReferenceDate ?? 0, -1609441200.0, "Reconstituted date failed")
+            XCTAssertEqual(sam?.birthdate.timeIntervalSinceReferenceDate ?? 0, -1609459200.0, "Reconstituted date failed")
         }
     }
     

--- a/Tests/GarageStorageTests/SwiftMigrationTests.swift
+++ b/Tests/GarageStorageTests/SwiftMigrationTests.swift
@@ -11,6 +11,10 @@ import GarageStorage
 
 class SwiftMigrationTests: XCTestCase {
 
+    override class func setUp() {
+        TestSetup.classSetUp()
+    }
+    
     override func setUp() {
         // Reset the underlying storage before running each test.
         let garage = Garage()

--- a/Tests/GarageStorageTests/TestSetup.swift
+++ b/Tests/GarageStorageTests/TestSetup.swift
@@ -1,0 +1,19 @@
+//
+//  TestSetup.swift
+//  GarageStorageTests
+//
+//  Created by Bob Gilmore on 5/10/21.
+//
+
+import Foundation
+
+@objc public class TestSetup: NSObject {
+    
+    static var timeZone = TimeZone(identifier: "UTC")!
+    
+    static func classSetUp() {
+        // Set the test time zone to UTC so that tests can compare with hardcoded UTC dates
+        NSTimeZone.default = TestSetup.timeZone
+    }
+    
+}

--- a/Tests/GarageStorageTests/TestableEdgeCaseTests.swift
+++ b/Tests/GarageStorageTests/TestableEdgeCaseTests.swift
@@ -15,6 +15,10 @@ import CoreData
 // This set of tests require access to internal GarageStorage APIs, to varying degrees.
 class TestableEdgeCaseTests: XCTestCase {
     
+    override class func setUp() {
+        TestSetup.classSetUp()
+    }
+    
     override func setUp() {
         // Reset the underlying storage before running each test.
         let garage = Garage()
@@ -131,7 +135,7 @@ class TestableEdgeCaseTests: XCTestCase {
         
     func testDateFormatter() {
         
-        let timeZone = TimeZone(identifier: "America/New_York")!
+        let timeZone = TestSetup.timeZone
         var dateComponents = DateComponents()
         dateComponents.day = 1
         dateComponents.month = 1
@@ -141,11 +145,11 @@ class TestableEdgeCaseTests: XCTestCase {
         var calendar = Calendar.current
         calendar.timeZone = timeZone
         let date = calendar.date(from: dateComponents)!
-        XCTAssertEqual(date.timeIntervalSinceReferenceDate, -1609441200.0, "Making assumption about the test")
+        XCTAssertEqual(date.timeIntervalSinceReferenceDate, -1609459200.0, "Making assumption about the test")
 
         do {
             let dateString = date.isoString
-            XCTAssertEqual(dateString, "1950-01-01T05:00:00Z", "isoString failed")
+            XCTAssertEqual(dateString, "1950-01-01T00:00:00Z", "isoString failed")
         }
         
         do {


### PR DESCRIPTION
Accounts for the fact that the Formatter in IsoFormattedDate has its own TimeZone.
Since its formatter is tinitalized at class initialization, the test methods (or even the
dynamic test setUp methods) set the global time zone too late to affect that object.

The only solution I’ve found is to set it globally on every test class’s class setUp
method, thereby ensuring that it will be set at least once before the IsoFormattedDate
class is loaded.