### PR TITLE
WFMOB-11519: added a version of retrieveAll that uses the objectClass…

### DIFF
--- a/Sources/GarageStorage/Garage+Codable.swift
+++ b/Sources/GarageStorage/Garage+Codable.swift
@@ -316,8 +316,8 @@ extension Garage {
     
     /// Returns all the objects of type T conforming to Codable that have a given sync status
     ///
-    /// - parameter syncStatus: The Sync Status
     /// - parameter objectClass: The class of the objects to retrieve
+    /// - parameter syncStatus: The Sync Status
     ///
     /// - returns: An array of objects of type T conforming to Codable. If no objects are found, an empty array is returned.
     public func retrieveAll<T: Decodable & Syncable>(_ objectClass: T.Type, withStatus syncStatus: SyncStatus) throws -> [T] {

--- a/Sources/GarageStorage/Garage+Codable.swift
+++ b/Sources/GarageStorage/Garage+Codable.swift
@@ -314,6 +314,18 @@ extension Garage {
         return try makeSyncableObjects(from: coreDataObjects)
     }
     
+    /// Returns all the objects of type T conforming to Codable that have a given sync status
+    ///
+    /// - parameter syncStatus: The Sync Status
+    /// - parameter objectClass: The class of the objects to retrieve
+    ///
+    /// - returns: An array of objects of type T conforming to Codable. If no objects are found, an empty array is returned.
+    public func retrieveAll<T: Decodable & Syncable>(_ objectClass: T.Type, withStatus syncStatus: SyncStatus) throws -> [T] {
+        let className = String(describing: T.self)
+        let coreDataObjects = try fetchObjects(with: syncStatus, type: className)
+        return try makeSyncableObjects(from: coreDataObjects)
+    }
+
     // MARK: - Deleting
     
     private func deleteCoreDataObject<T>(_ object: T, identifier: String) throws {

--- a/Sources/GarageStorage/Garage+Mappable.swift
+++ b/Sources/GarageStorage/Garage+Mappable.swift
@@ -1,5 +1,5 @@
 //
-//  Garage+Reference.swift
+//  Garage+Mappable.swift
 //  GarageStorage
 //
 //  Created by Brian Arnold on 10/7/19.

--- a/Sources/GarageStorage/Garage+MappableObject.swift
+++ b/Sources/GarageStorage/Garage+MappableObject.swift
@@ -77,8 +77,8 @@ extension Garage {
         let kvc = object as! NSObject
         let mapping = type(of: object).objectMapping
         for (keyPath, jsonKey) in mapping.mappings {
-            // Note: if kvc.value(forKey:) is throwing an exception and the MappableObject is in Swift,
-            // it could be because the property lacks an '@objc' in front of it.
+            // Note: if kvc.value(forKey:) is throwing an exception (crashing) and the MappableObject is in Swift,
+            // it could be because the property lacks an '@objc' in front of it, or the property name doesn't match.
             let value = kvc.value(forKey: keyPath)
             
             if let mappableObject = value as? MappableObject {
@@ -211,6 +211,8 @@ extension Garage {
         let mapping = type(of: gsObject).objectMapping
         let kvc = gsObject // "as! NSObject" cast not needed here, because it was casted in gsClass
         for (keyPath, jsonKey) in mapping.mappings {
+            // Note: if kvc.setValue(forKey:) is throwing an exception (crashing) and the MappableObject is in Swift,
+            // it could be because the property lacks an '@objc' in front of it, or the property name doesn't match.
             let value = json[jsonKey]
             if let dictionary = value as? [String:Any], dictionary[CoreDataObject.Attribute.identifier] != nil {
                 if dictionary.isAnonymous {

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -236,7 +236,7 @@ class SwiftCodableTests: XCTestCase {
             XCTAssertNoThrow(try garage.parkAll([pet]), "parkAll")
         }
         
-        // Validate initial sync status of Persons
+        // Validate sync status of Persons
         do {
             // WARNING: This will succeed by accident, because there is only one object of type SwiftPerson syncing,
             // but if there was another object of a different type syncing, then this would fail.
@@ -249,7 +249,8 @@ class SwiftCodableTests: XCTestCase {
             //let undetermined: [?] = try garage.retrieveAll(withStatus: .undetermined)
             //XCTAssertEqual(undetermined.count, 4, "4 items should be undetermined")
             
-            // This will throw because there are different types of objects not synced
+            // This will throw because there are different types of objects not synced.
+            // Don't use retrieveAll without an objectClass if you work with heterogeneous objects that may have the same sync status.
             // let notSynced: [SwiftPerson] = try garage.retrieveAll(withStatus: .notSynced))
             
             // This is the correct way to fetch all of a specific type that are not synced
@@ -264,7 +265,7 @@ class SwiftCodableTests: XCTestCase {
         do {
             XCTAssertNoThrow(try garage.setSyncStatus(.notSynced, for: sam), "setSyncStatus")
             
-            // Add in an unrelated object, to ensure that retrieveAll works on just one type
+            // Add in an unrelated object type, to ensure that retrieveAll below works on just one type
             XCTAssertNoThrow(try garage.setSyncStatus(.notSynced, for: pet), "setSyncStatus")
             
             let syncing: [SwiftPerson] = try garage.retrieveAll(SwiftPerson.self, withStatus: .syncing)

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -227,14 +227,20 @@ class SwiftCodableTests: XCTestCase {
         let oldAddress = swiftAddress()
         let newAddress = swiftAddress2()
         
+        let pet = SwiftPet()
+        
         // Park heterogeneous objects
         do {
             XCTAssertNoThrow(try garage.parkAll([nick, emily, sam]), "parkAll")
             XCTAssertNoThrow(try garage.parkAll([oldAddress, newAddress]), "parkAll")
+            XCTAssertNoThrow(try garage.parkAll([pet]), "parkAll")
         }
         
         // Validate initial sync status of Persons
         do {
+            // WARNING: This will succeed by accident, because there is only one object of type SwiftPerson syncing,
+            // but if there was another object of a different type syncing, then this would fail.
+            // Use retrieveAll(_ objectClass: T, withStatus: SyncStatus) instead to focus on the specific type.
             let syncing: [SwiftPerson] = try garage.retrieveAll(withStatus: .syncing)
             
             XCTAssertEqual(syncing.count, 1, "1 item should be syncing")
@@ -243,25 +249,28 @@ class SwiftCodableTests: XCTestCase {
             //let undetermined: [?] = try garage.retrieveAll(withStatus: .undetermined)
             //XCTAssertEqual(undetermined.count, 4, "4 items should be undetermined")
             
-            let notSynced: [SwiftPerson] = try garage.retrieveAll(withStatus: .notSynced)
+            // This will throw because there are different types of objects not synced
+            // let notSynced: [SwiftPerson] = try garage.retrieveAll(withStatus: .notSynced))
+            
+            // This is the correct way to fetch all of a specific type that are not synced
+            let notSynced: [SwiftPerson] = try garage.retrieveAll(SwiftPerson.self, withStatus: .notSynced)
             XCTAssertEqual(notSynced.count, 0, "no items should be not synced")
         }
         catch {
-            XCTFail("retrieveObjects should not throw an error, \(error)")
+            XCTFail("retrieveAll should not throw an error, \(error)")
         }
         
         // Change Sam's sync status and validate that it changed
         do {
             XCTAssertNoThrow(try garage.setSyncStatus(.notSynced, for: sam), "setSyncStatus")
             
-            let syncing: [SwiftPerson] = try garage.retrieveAll(withStatus: .syncing)
+            // Add in an unrelated object, to ensure that retrieveAll works on just one type
+            XCTAssertNoThrow(try garage.setSyncStatus(.notSynced, for: pet), "setSyncStatus")
+            
+            let syncing: [SwiftPerson] = try garage.retrieveAll(SwiftPerson.self, withStatus: .syncing)
             XCTAssertEqual(syncing.count, 0, "items should be syncing")
             
-            // TODO: heterogeneous Codable subtype arrays
-            //let undetermined: [?] = try garage.retrieveAll(withStatus: .undetermined)
-            //XCTAssertEqual(undetermined.count, 4, "4 items should be undetermined")
-            
-            let notSynced: [SwiftPerson] = try garage.retrieveAll(withStatus: .notSynced)
+            let notSynced: [SwiftPerson] = try garage.retrieveAll(SwiftPerson.self, withStatus: .notSynced)
             XCTAssertEqual(notSynced.count, 1, "items should be not synced")
         }
         catch {

--- a/Tests/GarageStorageTests/TestObjects/Swift/SwiftPet.swift
+++ b/Tests/GarageStorageTests/TestObjects/Swift/SwiftPet.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brian Arnold on 1/4/24.
+//
+
+import Foundation
+import GarageStorage
+
+// In order to be a top-level type that is parked and retrieved in a garage, a type must conform to Mappable (a Codable with an identifier). This happens to be a reference type (class).
+// It may optionally implement Syncable.
+class SwiftPet: Mappable, Syncable {
+
+    // Map the identifier to a preferred property, if desired.
+    var id: String { name }
+    
+    // This example sets all properties to default values, so that an init() method is not required.
+    var name: String = ""
+    
+    var age: Int = 0
+        
+    // Types with sync status need to skip syncStatus for coding, because it's archived
+    // separately in the underlying core data object, in order to fetch based on sync status.
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case age
+    }
+    
+    // Syncable protocol
+    var syncStatus: SyncStatus = .notSynced
+}

--- a/Tests/GarageStorageTests/TestObjects/Swift/SwiftPet.swift
+++ b/Tests/GarageStorageTests/TestObjects/Swift/SwiftPet.swift
@@ -1,8 +1,9 @@
 //
-//  File.swift
-//  
+//  SwiftPet.swift
+//  GarageStorageTests
 //
 //  Created by Brian Arnold on 1/4/24.
+//  Copyright © 2024 Wellframe. All rights reserved.
 //
 
 import Foundation


### PR DESCRIPTION
Added a version of retrieveAll that uses the objectClass…, when there are multiple heterogeneous types that have the same sync status. Updated the unit test. Also added a comment in makeMappableObject that can help diagnose crashes, based on a similar comment in jsonDictionary.