### PR TITLE
Make a temporary change that throws an error if the core data object's gs_data is nil

### DIFF
--- a/Sources/GarageStorage/Garage+Codable.swift
+++ b/Sources/GarageStorage/Garage+Codable.swift
@@ -133,7 +133,14 @@ extension Garage {
     // MARK: - Retrieving
     
     private func makeCodable<T: Decodable>(from coreDataObject: CoreDataObject) throws -> T {
-        let codable: T = try decodeData(coreDataObject.data)
+        // OLD:
+        // let codable: T = try decodeData(coreDataObject.data)
+        // NEW:
+        guard let data = coreDataObject.gs_data else {
+            throw Garage.makeError("failed to retrieve gs_data from store of type \(T.self)")
+        }
+        let codable: T = try decodeData(data)
+        // END NEW
         return codable
     }
     

--- a/Tests/GarageStorageTests/RawStorageTests.swift
+++ b/Tests/GarageStorageTests/RawStorageTests.swift
@@ -1,0 +1,38 @@
+//
+//  RawStorageTests.swift
+//  
+//
+//  Created by Brian Arnold on 6/7/24.
+//
+
+import XCTest
+@testable import GarageStorage
+
+class TestCoreData: Codable { }
+
+final class RawStorageTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        let garage = Garage()
+        garage.deleteAllObjects()
+    }
+
+    /// Test what happens if a core data objeect is created, but its `gs_data` never got set.
+    func testRawStorage() throws {
+        let garage = Garage()
+              
+        do {
+            _ = garage.makeCoreDataObject("TestCoreData", identifier: "TestIdentifier")
+            garage.save()
+        }
+        
+        do {
+            let _: TestCoreData? = try garage.retrieve(TestCoreData.self, identifier: "TestIdentifier")
+        } catch {
+            // we want to catch the error, and verify it
+            XCTAssertTrue(error.localizedDescription.contains("failed to retrieve gs_data"))
+        }
+        
+    }
+
+}

--- a/Tests/GarageStorageTests/RawStorageTests.swift
+++ b/Tests/GarageStorageTests/RawStorageTests.swift
@@ -17,7 +17,7 @@ final class RawStorageTests: XCTestCase {
         garage.deleteAllObjects()
     }
 
-    /// Test what happens if a core data objeect is created, but its `gs_data` never got set.
+    /// Test what happens if a core data object is created, but its `gs_data` never got set.
     func testRawStorage() throws {
         let garage = Garage()
               


### PR DESCRIPTION
This is a targeted fix to a specific function called from a client app that is crashing while force-unwrapping gs_data, to throw an error instead of making the force-unwrap call. This could be generalized to other functions that also access data (which force unwraps gs_data).

Added a unit test point to reproduce the issue, and verify that it is resolved.

To verify the bug (crash in makeCodable<A>):

Comment out lines 139-142, then uncomment line 137.

Run the unit test and verify that the unit test point fails.

Repeat, restoring lines 139-142, and commenting out line 137.

Run the unit test and verify that the unit test throws the specified error.