### PR TITLE
Fix Garage default init to support a garage name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ The `Garage` is the main object that coordinates activity in Garage Storage. It'
 First, create a Garage:
 
 ```swift
-let garage = Garage()
+let garage = Garage(named: "MyGarage")
 ```
-If you wish to specify the name of the store, have multiple Garage stores, or add configuration options to your persistent store, you may alternatively create a garage with a `NSPersistentStoreDescription`. A convenience class method `makePeristentStoreDescription(_)` with a store name can be used to keep this step as simple as possible. 
+If you wish to have multiple Garage stores, or add configuration options to your persistent store, you may alternatively create a garage with a `NSPersistentStoreDescription`. A convenience class method `makePeristentStoreDescription(_)` with a store name can be used to keep this step as simple as possible. 
 
-**Note**: When this library requires iOS 10 or later, this will be replaced with `NSPersistentStoreDescription`.
 
 #### Objects in Swift
 Any Swift type that is involved in being parked in a Garage must conform to `Codable`. The Swift compiler will take care of synthesizing of `CodingKeys`, `init(from:)` and `encode(to:)` methods, or alternatively, you can specify them manually, as you might for any `Codable` type.

--- a/Sources/GarageStorage/Garage.swift
+++ b/Sources/GarageStorage/Garage.swift
@@ -47,12 +47,6 @@ public class Garage: NSObject {
     }
 
     // MARK: - Initializing
-    
-    private static var defaultStoreName = "GarageStorage.sqlite"
-    
-    private static var defaultDescription: NSPersistentStoreDescription = {
-        return makePersistentStoreDescription(defaultStoreName)
-    }()
 
     /// A convenience function that returns a NSPersistentStoreDescription of type NSSQLLiteStoreType, with a URL in the application Documents directory, of the specified store name.
     ///
@@ -69,8 +63,10 @@ public class Garage: NSObject {
     
     /// Creates a Garage with a default persistent store coordinator and object mapper.
     /// This convenience initializer will also load the persistent store.
-    public convenience override init() {
-        self.init(with: nil)
+    public convenience init(named garageName: String) {
+        let storeName = "\(garageName).sqlite"
+        let description = Garage.makePersistentStoreDescription(storeName)
+        self.init(with: [description])
         
         loadPersistentStores { (description, error) in
             if let error = error {
@@ -83,11 +79,11 @@ public class Garage: NSObject {
     ///
     /// - note: Once the Garage has been initialized, you need to execute `loadPersistentStores(completionHandler:)` to instruct the Garage to load the persistent stores and complete the creation of the Core Data stack.
     ///
-    /// - parameter persistentStoreDescriptions: An array of NSPersistentStoreDescription to use in the Garage's Core Data Stack. If nil is passed in, a default description will be used.
-    public init(with persistentStoreDescriptions: [NSPersistentStoreDescription]? = nil) {
+    /// - parameter persistentStoreDescriptions: An array of NSPersistentStoreDescription to use in the Garage's Core Data Stack.
+    public init(with persistentStoreDescriptions: [NSPersistentStoreDescription]) {
         let garageModel = GarageModel().makeModel()
         self.persistentContainer = NSPersistentContainer(name: Garage.modelName, managedObjectModel: garageModel)
-        let descriptions = persistentStoreDescriptions ?? [Garage.defaultDescription]
+        let descriptions = persistentStoreDescriptions
         self.persistentContainer.persistentStoreDescriptions = descriptions
         super.init()
     }

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -21,12 +21,12 @@ class MappableObjectTests: XCTestCase {
     
     override func setUp() {
         // Reset the underlying storage before running each test.
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         garage.deleteAllObjects()
     }
     
     func testMappableObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create a "Sam" person and park it.
         do {
@@ -50,7 +50,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testArrayOfMappable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create a pair of people and park them.
         do {
@@ -73,7 +73,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testMissingIdentifyingAttribute() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // This should emit a logging message.
         // FIX: Once the GS implementation is converted to Swift, as each implementation is
@@ -87,7 +87,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testMissingReferencedObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
 
         // Create a "Sam" person and park it.
         do {
@@ -112,7 +112,7 @@ class MappableObjectTests: XCTestCase {
     
     func testNilObject() {
         // This tests the Objective-C interface to parkObject, which throws in Swift.
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // This should emit a logging message, and an error.
         
@@ -122,7 +122,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testRetrievingCollections() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -155,7 +155,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testDeletingObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -182,7 +182,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testDeletingCollections() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -215,7 +215,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testDeletingAllObjects() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -253,7 +253,7 @@ class MappableObjectTests: XCTestCase {
     }
 
     func testSyncStatus() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         let sam = objCPerson()
         let nick = objCPerson2()
@@ -326,7 +326,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testInvalidSyncStatus() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create, but don't park, sam
         let sam = objCPerson()
@@ -338,7 +338,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testDates() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let sam = objCPerson()

--- a/Tests/GarageStorageTests/RawStorageTests.swift
+++ b/Tests/GarageStorageTests/RawStorageTests.swift
@@ -13,13 +13,13 @@ class TestCoreData: Codable { }
 final class RawStorageTests: XCTestCase {
 
     override func setUpWithError() throws {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         garage.deleteAllObjects()
     }
 
     /// Test what happens if a core data object is created, but its `gs_data` never got set.
     func testRawStorage() throws {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
               
         do {
             _ = garage.makeCoreDataObject("TestCoreData", identifier: "TestIdentifier")

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -19,12 +19,12 @@ class SwiftCodableTests: XCTestCase {
     
     override func setUp() {
         // Reset the underlying storage before running each test.
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         garage.deleteAllObjects()
     }
     
     func testMappable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create a "Sam" person and park it.
         do {
@@ -49,7 +49,7 @@ class SwiftCodableTests: XCTestCase {
 
 
     func testArrayOfMappable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create a pair of people and park them.
         do {
@@ -72,7 +72,7 @@ class SwiftCodableTests: XCTestCase {
     }
 
     func testRetrievingCollections() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -115,7 +115,7 @@ class SwiftCodableTests: XCTestCase {
     
 
     func testDeletingObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -143,7 +143,7 @@ class SwiftCodableTests: XCTestCase {
     }
  
     func testDeletingCollections() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -178,7 +178,7 @@ class SwiftCodableTests: XCTestCase {
 
 
     func testDeletingAllObjects() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Park heterogeneous objects
         do {
@@ -218,7 +218,7 @@ class SwiftCodableTests: XCTestCase {
 
 
     func testSyncStatus() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         let sam = swiftPerson()
         let nick = swiftPerson2()
@@ -286,7 +286,7 @@ class SwiftCodableTests: XCTestCase {
     }
     
     func testInvalidSyncStatus() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Create, but don't park, sam
         let sam = swiftPerson()
@@ -298,7 +298,7 @@ class SwiftCodableTests: XCTestCase {
     }
     
     func testDates() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let sam = swiftPerson()
@@ -329,7 +329,7 @@ class SwiftCodableTests: XCTestCase {
     }
     
     func testMappables() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
 
         do {
             // Configure a tree consisting of lots of referenced branches

--- a/Tests/GarageStorageTests/SwiftMigrationTests.swift
+++ b/Tests/GarageStorageTests/SwiftMigrationTests.swift
@@ -17,12 +17,12 @@ class SwiftMigrationTests: XCTestCase {
     
     override func setUp() {
         // Reset the underlying storage before running each test.
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         garage.deleteAllObjects()
     }
 
     func testOneMappable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let nick = objCPerson2()
@@ -39,7 +39,7 @@ class SwiftMigrationTests: XCTestCase {
     }
     
     func testNestedMappable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Save Sam as a MappableObject (Objective-C-based) person
         do {

--- a/Tests/GarageStorageTests/TestSetup.swift
+++ b/Tests/GarageStorageTests/TestSetup.swift
@@ -17,3 +17,6 @@ import Foundation
     }
     
 }
+
+/// Use this test store name for Garage Storage tests.
+let testStoreName = "GarageStorageTests"

--- a/Tests/GarageStorageTests/TestableEdgeCaseTests.swift
+++ b/Tests/GarageStorageTests/TestableEdgeCaseTests.swift
@@ -21,7 +21,7 @@ class TestableEdgeCaseTests: XCTestCase {
     
     override func setUp() {
         // Reset the underlying storage before running each test.
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         garage.deleteAllObjects()
     }
          
@@ -32,7 +32,7 @@ class TestableEdgeCaseTests: XCTestCase {
     }
     
     func testArrayOfArray() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let backpack = InfiniteBag("Backpack")
@@ -56,7 +56,7 @@ class TestableEdgeCaseTests: XCTestCase {
     }
     
     func testSyncableAnonymous() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let address = ObjCSyncingAddress()
@@ -90,7 +90,7 @@ class TestableEdgeCaseTests: XCTestCase {
     }
     
     func testMissingIdentifiable() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         do {
             let fox = ObjCFox()
             // Oops, missing identifiableAttribute: fox.name = "Sam"
@@ -108,7 +108,7 @@ class TestableEdgeCaseTests: XCTestCase {
         print("Skipping test for missing @objc, because value(forKey:) throws an exception that isn't caught by XCTest")
         /*
          TODO: when we can catch an exception from value(forKey:) we can re-enabled this
-         let garage = Garage()
+         let garage = Garage(named: testStoreName)
          do {
          let goat = Goat()
          goat.name = "Sam"


### PR DESCRIPTION
Fix the default initializer to require a garage name that is used instead of the default garage name. Add a testGarageName that is shared across the unit tests.