### PR TITLE
Relax the requirement that an object must already exist in local storage for Codable types.

### DIFF
--- a/Sources/GarageStorage/Garage+Codable.swift
+++ b/Sources/GarageStorage/Garage+Codable.swift
@@ -158,7 +158,7 @@ extension Garage {
     /// - returns: An object conforming to the specified class, or nil if it was not found.
     public func retrieve<T: Decodable>(_ objectClass: T.Type, identifier: String) throws -> T? {
         let className = String(describing: T.self)
-        let coreDataObject = try fetchCoreDataObject(for: className, identifier: identifier)
+        guard let coreDataObject = fetchObject(for: className, identifier: identifier) else { return nil }
         return try makeCodable(from: coreDataObject)
     }
     
@@ -170,7 +170,7 @@ extension Garage {
     /// - returns: An object conforming to the specified class, or nil if it was not found.
     public func retrieve<T: Decodable & Syncable>(_ objectClass: T.Type, identifier: String) throws -> T? {
         let className = String(describing: T.self)
-        let coreDataObject = try fetchCoreDataObject(for: className, identifier: identifier)
+        guard let coreDataObject = fetchObject(for: className, identifier: identifier) else { return nil }
         return try makeSyncable(from: coreDataObject)
     }
     

--- a/Sources/GarageStorage/Garage+MappableObject.swift
+++ b/Sources/GarageStorage/Garage+MappableObject.swift
@@ -333,12 +333,10 @@ extension Garage {
 
     // MARK: - Retrieving
     
-    private func retrieveMappableObject(_ objectClass: AnyClass, identifier: String) throws -> MappableObject {
+    private func retrieveMappableObject(_ objectClass: AnyClass, identifier: String) throws -> MappableObject? {
         let className = NSStringFromClass(objectClass)
         
-        guard let coreDataObject = fetchObject(for: className, identifier: identifier) else {
-            throw Garage.makeError("failed to retrieve object of class: \(className) identifier: \(identifier)")
-        }
+        guard let coreDataObject = fetchObject(for: className, identifier: identifier) else { return nil }
         
         return try makeMappableObject(from: coreDataObject)
     }
@@ -361,7 +359,11 @@ extension Garage {
     /// - returns: An object conforming to GSMappableObject.
     @objc(retrieveObjectOfClass:identifier:error:)
     public func __retrieveObjectObjC(_ objectClass: AnyClass, identifier: String) throws -> Any {
-        return try retrieveMappableObject(objectClass, identifier: identifier)
+        guard let object = try retrieveMappableObject(objectClass, identifier: identifier) else {
+            // This "throws" an error in order for the return value to be nil in Objective-C.
+            throw Garage.makeError("failed to retrieve object of class: \(className) identifier: \(identifier)")
+        }
+        return object
     }
 
     private func makeMappableObjects(from coreDataObjects: [CoreDataObject]) throws -> [MappableObject] {

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -368,9 +368,21 @@ class MappableObjectTests: XCTestCase {
     func testNonExistentObject() {
         let garage = Garage()
         
+        // Swift behavior: be able to return nil for not found, not throw an error.
         do {
-            let sam = try? garage.retrieveObject(ObjCPerson.self, identifier: "Frodo")
-            XCTAssertNil(sam, "Should not have found Frodo")
+            let frodo = try garage.retrieveObject(ObjCPerson.self, identifier: "Frodo")
+            XCTAssertNil(frodo, "Should be nil")
+        }
+        catch {
+            XCTFail("Should not have thrown an error: \(error)")
+        }
+        
+        // Objective-C behavior: throw an error so that the ObjC runtime can return nil to an ObjC caller.
+        do {
+            _ = try garage.__retrieveObjectObjC(ObjCPerson.self, identifier: "Frodo")
+            XCTFail("Should have thrown an error")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("failed to retrieve object"))
         }
     }
 }

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -364,4 +364,13 @@ class MappableObjectTests: XCTestCase {
             XCTAssertEqual(sam?.birthdate.timeIntervalSinceReferenceDate ?? 0, -1609459200.0, "Reconstituted date failed")
         }
     }
+    
+    func testNonExistentObject() {
+        let garage = Garage()
+        
+        do {
+            let sam = try? garage.retrieveObject(ObjCPerson.self, identifier: "Frodo")
+            XCTAssertNil(sam, "Should not have found Frodo")
+        }
+    }
 }

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -373,8 +373,8 @@ class SwiftCodableTests: XCTestCase {
         let garage = Garage()
         
         do {
-            let sam = try garage.retrieve(SwiftPerson.self, identifier: "Sam")
-            XCTAssertNil(sam, "Should be nil")
+            let frodo = try garage.retrieve(SwiftPerson.self, identifier: "Frodo")
+            XCTAssertNil(frodo, "Should be nil")
         }
         catch {
             XCTFail("Should not have thrown an error: \(error)")

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -368,4 +368,16 @@ class SwiftCodableTests: XCTestCase {
 
         }
     }
+    
+    func testNonExistentObject() {
+        let garage = Garage()
+        
+        do {
+            let sam = try garage.retrieve(SwiftPerson.self, identifier: "Sam")
+            XCTAssertNil(sam, "Should be nil")
+        }
+        catch {
+            XCTFail("Should not have thrown an error: \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Due to a limitation in how an Objective-C compatible throwable method can be declared, the return type must be non-optional, so that the Objective-C runtime can return nil when an error is thrown. This limitation was incorporated into the Objective-C version of the retrieveObject method, but because the test to throw the error was deep inside the implementation, it also propagated to the Swift MappableObject version of the retrieveObject method and the Swift-only Codable retrieve<T> methods, even though those could already support returning nil.

This MR relaxes the constraint on the Codable retrieve<T> methods and Swift MappableObject retrieveObject method, so that nil can be returned without requiring throwing an error "object not found". The test to throw the error was moved to the Objective-C-only version of the retrieveObject method.

Test points were added for all three functions to illustrate the difference.