### PR TITLE
Generalize gs data nil check to MappableObject

### DIFF
--- a/Sources/GarageStorage/Garage+Codable.swift
+++ b/Sources/GarageStorage/Garage+Codable.swift
@@ -133,14 +133,10 @@ extension Garage {
     // MARK: - Retrieving
     
     private func makeCodable<T: Decodable>(from coreDataObject: CoreDataObject) throws -> T {
-        // OLD:
-        // let codable: T = try decodeData(coreDataObject.data)
-        // NEW:
         guard let data = coreDataObject.gs_data else {
             throw Garage.makeError("failed to retrieve gs_data from store of type \(T.self)")
         }
         let codable: T = try decodeData(data)
-        // END NEW
         return codable
     }
     

--- a/Sources/GarageStorage/Garage+MappableObject.swift
+++ b/Sources/GarageStorage/Garage+MappableObject.swift
@@ -171,7 +171,10 @@ extension Garage {
     
     private func makeMappableObject(from coreDataObject: CoreDataObject) throws -> MappableObject {
         let className = coreDataObject.gs_type!
-        let mappedObject = try decodeData(coreDataObject.data, className: className)
+        guard let data = coreDataObject.gs_data else {
+            throw Garage.makeError("failed to retrieve gs_data from store of type \(className)")
+        }
+        let mappedObject = try decodeData(data, className: className)
         
         if let syncableObject = mappedObject as? SyncableObject {
             syncableObject.syncStatus = coreDataObject.syncStatus

--- a/Tests/GarageStorageTests/MappableObjectTests.swift
+++ b/Tests/GarageStorageTests/MappableObjectTests.swift
@@ -366,7 +366,7 @@ class MappableObjectTests: XCTestCase {
     }
     
     func testNonExistentObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         // Swift behavior: be able to return nil for not found, not throw an error.
         do {

--- a/Tests/GarageStorageTests/SwiftCodableTests.swift
+++ b/Tests/GarageStorageTests/SwiftCodableTests.swift
@@ -370,7 +370,7 @@ class SwiftCodableTests: XCTestCase {
     }
     
     func testNonExistentObject() {
-        let garage = Garage()
+        let garage = Garage(named: testStoreName)
         
         do {
             let frodo = try garage.retrieve(SwiftPerson.self, identifier: "Frodo")


### PR DESCRIPTION
The initial gs_data nil check was added only to the Codable implementation, to work around a data race that was corrupting gs_data. That check has been confirmed as working in client code, so is now being extended to the MappableObject implementation.